### PR TITLE
Use auto-changelog without shell variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,11 +35,11 @@ Initial release
 ## :question: Automatic Release Notes
 
 This extension automatically generates release notes by running
-`npx auto-changelog --hide-empty-releases --hide-credit > CHANGELOG.md` and then
-creating a GitHub release with `gh release create`. For example:
+`npx auto-changelog --hide-empty-releases --hide-credit --output CHANGELOG.md`
+and then creating a GitHub release with `gh release create`. For example:
 
 ```bash
-npx auto-changelog --hide-empty-releases --hide-credit > CHANGELOG.md
+npx auto-changelog --hide-empty-releases --hide-credit --output CHANGELOG.md
 gh release create v1.2.1 -t v1.2.1 -F ./CHANGELOG.md
 ```
 

--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ Initial release
 
 ## :question: Automatic Release Notes
 
-This extension automatically generates release notes by running `auto-changelog --ending-version v$VERSION --hide-empty-releases --hide-credit` and passing the
-result to `gh release create`.
+This extension automatically generates release notes by running `auto-changelog --hide-empty-releases --hide-credit` and passing the
+result to `gh release create` with the current version from `package.json`.
 
 You can also supply the `--generate-notes` flag to `gh release create` if you
 want GitHub to guess the notes for you.

--- a/README.md
+++ b/README.md
@@ -34,8 +34,14 @@ Initial release
 
 ## :question: Automatic Release Notes
 
-This extension automatically generates release notes by running `auto-changelog --hide-empty-releases --hide-credit` and passing the
-result to `gh release create` with the current version from `package.json`.
+This extension automatically generates release notes by running
+`auto-changelog --hide-empty-releases --hide-credit > CHANGELOG.md` and then
+creating a GitHub release with `gh release create`. For example:
+
+```bash
+auto-changelog --hide-empty-releases --hide-credit > CHANGELOG.md
+gh release create v1.2.1 -t v1.2.1 -F ./CHANGELOG.md
+```
 
 You can also supply the `--generate-notes` flag to `gh release create` if you
 want GitHub to guess the notes for you.

--- a/README.md
+++ b/README.md
@@ -35,11 +35,11 @@ Initial release
 ## :question: Automatic Release Notes
 
 This extension automatically generates release notes by running
-`auto-changelog --hide-empty-releases --hide-credit > CHANGELOG.md` and then
+`npx auto-changelog --hide-empty-releases --hide-credit > CHANGELOG.md` and then
 creating a GitHub release with `gh release create`. For example:
 
 ```bash
-auto-changelog --hide-empty-releases --hide-credit > CHANGELOG.md
+npx auto-changelog --hide-empty-releases --hide-credit > CHANGELOG.md
 gh release create v1.2.1 -t v1.2.1 -F ./CHANGELOG.md
 ```
 

--- a/extension.js
+++ b/extension.js
@@ -45,9 +45,9 @@ const publishModule = (level, git = false, githubRelease = false) => {
     if (git) terminal.sendText('git push --follow-tags')
 
     if (githubRelease) {
-      terminal.sendText('VERSION=$(node -p "require(\"./package.json\").version")')
-      terminal.sendText('auto-changelog --ending-version v$VERSION --hide-empty-releases --hide-credit > /tmp/release-notes.md')
-      terminal.sendText('gh release create v$VERSION -t v$VERSION -F /tmp/release-notes.md')
+      const version = require('./package.json').version
+      terminal.sendText('auto-changelog --hide-empty-releases --hide-credit > /tmp/release-notes.md')
+      terminal.sendText(`gh release create v${version} -t v${version} -F /tmp/release-notes.md`)
     }
 
   } catch (err) {

--- a/extension.js
+++ b/extension.js
@@ -46,7 +46,7 @@ const publishModule = (level, git = false, githubRelease = false) => {
 
     if (githubRelease) {
       const version = require('./package.json').version
-      terminal.sendText('auto-changelog --hide-empty-releases --hide-credit > CHANGELOG.md')
+      terminal.sendText('npx auto-changelog --hide-empty-releases --hide-credit > CHANGELOG.md')
       terminal.sendText(`gh release create v${version} -t v${version} -F ./CHANGELOG.md`)
     }
 

--- a/extension.js
+++ b/extension.js
@@ -46,8 +46,8 @@ const publishModule = (level, git = false, githubRelease = false) => {
 
     if (githubRelease) {
       const version = require('./package.json').version
-      terminal.sendText('auto-changelog --hide-empty-releases --hide-credit > /tmp/release-notes.md')
-      terminal.sendText(`gh release create v${version} -t v${version} -F /tmp/release-notes.md`)
+      terminal.sendText('auto-changelog --hide-empty-releases --hide-credit > CHANGELOG.md')
+      terminal.sendText(`gh release create v${version} -t v${version} -F ./CHANGELOG.md`)
     }
 
   } catch (err) {

--- a/extension.js
+++ b/extension.js
@@ -46,7 +46,7 @@ const publishModule = (level, git = false, githubRelease = false) => {
 
     if (githubRelease) {
       const version = require('./package.json').version
-      terminal.sendText('npx auto-changelog --hide-empty-releases --hide-credit > CHANGELOG.md')
+      terminal.sendText('npx auto-changelog --hide-empty-releases --hide-credit --output CHANGELOG.md')
       terminal.sendText(`gh release create v${version} -t v${version} -F ./CHANGELOG.md`)
     }
 


### PR DESCRIPTION
## Summary
- simplify changelog generation
- document auto-changelog command update

## Testing
- `npm test` *(fails: Running as root without --no-sandbox is not supported)*